### PR TITLE
Dispatch tools SSL

### DIFF
--- a/python/qpid_dispatch/management/client.py
+++ b/python/qpid_dispatch/management/client.py
@@ -75,30 +75,46 @@ class Entity(EntityBase):
 class Node(object):
     """Client proxy for an AMQP management node"""
 
-    def __init__(self, url=None, router=None, locales=None, timeout=10, connection=None):
-        """
+    @staticmethod
+    def connection(url=None, router=None, timeout=10, ssl_domain=None):
+        """Return a BlockingConnection suitable for connecting to a management node
         @param url: URL of the management node.
         @param router: If address does not contain a path, use the management node for this router ID.
             If not specified and address does not contain a path, use the default management node.
+        """
+        url = Url(url)          # Convert string to Url class.
+
+        # Dispatch always allows SASL and requires it unless allow-no-sasl is configured.
+        # Add anonymous@ by default to tell proton we want SASL ANONYMOUS.
+        # FIXME aconway 2015-02-17: this may change when proton supports more SASL mechs.
+        if not url.username:
+            url.username = "anonymous"
+
+        if url.path is None:
+            if router:
+                url.path = '_topo/0/%s/$management' % router
+            else:
+                url.path = '$management'
+
+        return BlockingConnection(url, timeout=timeout, ssl_domain=ssl_domain)
+
+    @staticmethod
+    def connect(url=None, router=None, timeout=10, ssl_domain=None):
+        """Return a Node connected with the given parameters, see L{connection}"""
+        return Node(Node.connection(url, router, timeout, ssl_domain))
+
+    def __init__(self, connection, locales=None):
+        """
+        Create a management node proxy using the given connection.
         @param locales: Default list of locales for management operations.
-        @param client: a L{BlockingConnection}
+        @param connection: a L{BlockingConnection} to the management agent.
         """
         self.name = self.identity = 'self'
         self.type = 'org.amqp.management' # AMQP management node type
-        self.url = Url(url).defaults()
-
-        # Dispatch requires SASL, default to anonymous user to trigger ANONYMOUS mechanism.
-        # FIXME aconway 2015-02-17: this may change when proton SASL support is implemented.
-        if not self.url.username:
-            self.url.username = "anonymous"
+        self.locales = locales
 
         self.locales = locales
-        if self.url.path is None:
-            if router:
-                self.url.path = '_topo/0/%s/$management' % router
-            else:
-                self.url.path = '$management'
-        connection = connection or BlockingConnection(self.url, timeout)
+        self.url = connection.url
         self.client = SyncRequestResponse(connection, self.url.path)
         self.reply_to = self.client.reply_to
 

--- a/python/qpid_dispatch_internal/tools/command.py
+++ b/python/qpid_dispatch_internal/tools/command.py
@@ -24,6 +24,12 @@ Utilities for command-line programs.
 import sys, json, optparse, os
 from collections import Sequence, Mapping
 from qpid_dispatch_site import VERSION
+from proton import SSLDomain
+try:
+    from proton.utils import SyncRequestResponse, BlockingConnection, SSLDomain
+except ImportError:
+    from qpid_dispatch_internal.proton_future.utils import SyncRequestResponse, BlockingConnection
+
 
 class UsageError(Exception):
     """
@@ -71,14 +77,29 @@ def connection_options(options, title="Connection Options"):
                      metavar="ROUTER-ID", help="Router to be queried")
     group.add_option("-t", "--timeout", action="store", type="float", default=5, metavar="SECS",
                       help="Maximum time to wait for connection in seconds (default %default)")
-    group.add_option("--sasl-mechanism", action="store", type="string", metavar="MECH",
-                      help="Force SASL mechanism (e.g. EXTERNAL, ANONYMOUS, PLAIN, CRAM-MD5, DIGEST-MD5, GSSAPI).")
     group.add_option("--ssl-certificate", action="store", type="string", metavar="CERT",
                      help="Client SSL certificate (PEM Format)")
     group.add_option("--ssl-key", action="store", type="string", metavar="KEY",
                      help="Client SSL private key (PEM Format)")
+    group.add_option("--ssl-trustfile", action="store", type="string", metavar="TRUSTED-CA-DB",
+                     help="Trusted Certificate Authority Database file (PEM Format)")
+    group.add_option("--ssl-password", action="store", type="string", metavar="TRUSTED-CA-DB",
+                     help="Certificate password, will be prompted if not specifed.")
     return group
 
+def ssl_domain(options, mode=SSLDomain.MODE_CLIENT):
+    """Return proton.SSLDomain from command line options or None if no SSL options specified.
+    @param options: Parsed optoins including connection_options()
+    """
+    certificate, key, trustfile, password = options.ssl_certificate, options.ssl_key, options.ssl_trustfile, options.ssl_password
+    if not (certificate or trustfile): return None
+    domain = SSLDomain(mode)
+    if trustfile:
+        domain.set_trusted_ca_db(trustfile)
+        domain.set_peer_authentication(SSLDomain.VERIFY_PEER, trustfile)
+    if certificate:
+        domain.set_credentials(certificate, key, password)
+    return domain
 
 class Option(optparse.Option):
     """Addes two new types to optparse.Option: json_map, json_list"""

--- a/tools/qdmanage
+++ b/tools/qdmanage
@@ -24,7 +24,7 @@ import  qpid_dispatch_site
 from qpid_dispatch.management.client import Node, Url
 from collections import Mapping, Sequence
 from optparse import OptionGroup
-from qpid_dispatch_internal.tools.command import OptionParser, Option, UsageError, connection_options, check_args, main
+from qpid_dispatch_internal.tools.command import OptionParser, Option, UsageError, connection_options, check_args, main, ssl_domain
 
 def attr_split(attrstr):
     """Split an attribute string of the form name=value or name to indicate None"""
@@ -61,7 +61,8 @@ class QdManage():
         self.opts, self.args = self.op.parse_args(argv[1:])
         if len(self.args) == 0: raise UsageError("No operation specified")
         operation = self.args.pop(0)
-        self.node = Node(Url(self.opts.bus), self.opts.router)
+        self.node = Node.connect(
+            self.opts.bus, self.opts.router, self.opts.timeout, ssl_domain(self.opts))
         if operation.upper() in self.operations:
             method = getattr(self, operation.lower().replace('-','_'))
             method()

--- a/tools/qdstat
+++ b/tools/qdstat
@@ -30,25 +30,10 @@ import  qpid_dispatch_site
 from qpid_dispatch.management.client import Url, Node, Entity
 from qpid_dispatch_internal.management.qdrouter import QdSchema
 from qpid_dispatch_internal.tools import Display, Header, Sorter, YN, Commas, TimeLong
-from qpid_dispatch_internal.tools.command import connection_options, main, OptionParser
+from qpid_dispatch_internal.tools.command import connection_options, main, OptionParser, ssl_domain
 
-
-class Config:
-    def __init__(self):
-        self._connTimeout = 5
-        self._types = ""
-        self._limit = 50
-        self._increasing = False
-        self._sortcol = None
-
-config = Config()
-conn_options = {}
-
-def OptionsAndArguments(argv):
+def parse_args(argv):
     """ Set global variables for options, return arguments """
-
-    global config
-    global conn_options
 
     usage = "%prog [options]"
 
@@ -68,17 +53,17 @@ def OptionsAndArguments(argv):
     if not opts.show:
         parser.error("You must specify one of these options: -g, -c, -l, -n, -a, -m or -h.")
 
-    config._types = opts.show
-    config._address = opts.bus
-    config._router = opts.router
-    config._connTimeout = opts.timeout
-
-    return args
+    return opts, args
 
 
 class BusManager(Node):
 
     schema = QdSchema()
+
+    def __init__(self, opts):
+        self.opts = opts
+        super(BusManager, self).__init__(
+            Node.connection(opts.bus, opts.router, timeout=opts.timeout, ssl_domain=ssl_domain(opts)))
 
     def query(self, entity_type):
         return super(BusManager, self).query(entity_type).get_entities()
@@ -307,11 +292,11 @@ class BusManager(Node):
         elif main == 'c': self.displayConnections()
 
     def display(self, identitys):
-        self.displayMain(identitys, config._types)
+        self.displayMain(identitys, self.opts.show)
 
 def run(argv):
-    args = OptionsAndArguments(argv)
-    bm = BusManager(config._address, config._router)
+    opts, args = parse_args(argv)
+    bm = BusManager(opts)
     try:
         bm.display(args)
     finally:


### PR DESCRIPTION
Added support for SSL connections from qdmanage and qdstat tools.

Common command line option handling and SSL config code in qpid_dispatch_internal.tools.command
for existing and future tools.

Common options are:

  Connection Options:
    -b URL, --bus=URL   URL of the messaging bus to connect to (default 0.0.0.0)
    -r ROUTER-ID, --router=ROUTER-ID
                        Router to be queried
    -t SECS, --timeout=SECS
                        Maximum time to wait for connection in seconds (default 5)
    --ssl-certificate=CERT
                        Client SSL certificate (PEM Format)
    --ssl-key=KEY       Client SSL private key (PEM Format)
    --ssl-trustfile=TRUSTED-CA-DB
                        Trusted Certificate Authority Database file (PEM Format)
    --ssl-password=TRUSTED-CA-DB
                        Certificate password, will be prompted if not specifed.

NOTE: --sasl-mechanism option was removed. Presently proton only supports
ANONYMOUS and PLAIN and will auto-detect the SASL mechanism from the URL as
follows:

amqp://host - no SASL at all
amqp://anonymous@host - ANONYMOUS mechanism
amqp://user:password@host - PLAIN mechanism

Additional SASL support is in progress, we will update the tools when it is clear how
additional mechanisms are specified.